### PR TITLE
无用依赖删除

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <java.version>1.8</java.version>
         <log4j2.version>2.17.1</log4j2.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -48,12 +49,6 @@
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>1.2.79</version>
-        </dependency>
-
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.19</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
PS:mysql-connector-java 8.0.19 存在安全漏洞，如使用请升级至8.0.27及以上